### PR TITLE
Add a debug flag to pipeline to inspect stage failures

### DIFF
--- a/nanotrace/pipeline.py
+++ b/nanotrace/pipeline.py
@@ -46,7 +46,7 @@ class Pipeline:
     """
 
     def __init__(self, *stages: Sequence[Callable], n_jobs: int=1,
-                 features: Sequence[Callable] | None=None, **kwargs) -> None:
+                 features: Sequence[Callable] | None=None, debug: bool=False, **kwargs) -> None:
         """
         A pipeline is constructed as a linear list of pipeline "stages".
 
@@ -59,6 +59,7 @@ class Pipeline:
         self.stages = list(stages)
         self.features = [*features] if features is not None else []
         self.n_jobs = n_jobs
+        self.debug = debug
         self.kwargs = kwargs
 
     def __str__(self) -> str:
@@ -106,7 +107,7 @@ class Pipeline:
 
         if not key in self._cache:
             logger.debug("Creating tree from root: %s", key)
-            rt = root(source, self.stages, pipeline=self, features=self.features, **self.kwargs)
+            rt = root(source, self.stages, pipeline=self, features=self.features, debug=self.debug, **self.kwargs)
             # Absolute file path is used as a key for caching, could use file hash
             self._cache[key] = rt
         logger.debug("Returning cached tree")

--- a/nanotrace/segment.py
+++ b/nanotrace/segment.py
@@ -16,6 +16,7 @@ limitations under the License.
 """
 
 import logging
+import warnings
 from typing import Sequence, Callable
 
 import numpy as np
@@ -98,7 +99,7 @@ class Root(Node):
     Root takes care of calculating features over all events.
     """
     def __init__(self, *args, pipeline: pipeline.Pipeline, n_segments: int=-1,
-                 features: Sequence | None=None, post: Callable | None=None, **kwargs) -> None:
+                 features: Sequence | None=None, post: Callable | None=None, debug: bool=False, **kwargs) -> None:
         """
         Root constructor only sets up generic pipeline stuff.
         Specific roots that subclass this handle their specific tree setup.
@@ -119,6 +120,7 @@ class Root(Node):
             features = []
         self.extractors = features
         self.post = post
+        self.debug = debug
         self.n_segments = n_segments
 
     @property
@@ -281,8 +283,11 @@ class Segment(Node):
                     seg.parent = self
                     if i == self.n_segments:
                         break
-            except StageError:
-                logger.warning("Stage %s failed"%self.stage.__name__)
+            except StageError as e:
+                if self.root.debug:
+                    raise e
+                else:
+                    warnings.warn("Stage %s failed"%self.stage.__name__)
 
     @Node.children.getter
     def children(self):


### PR DESCRIPTION
Stages used to fail with only a warning to not interrupt a long calculation, but this makes it hard to debug actual broken stages.
This adds an optional debug flag to the Pipeline that makes StageErrors actually fail the calculation.